### PR TITLE
fix eslint issue importing json files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -33,12 +33,11 @@
           }
     },
     "rules": {
-        "import/extensions": [2, {
+        "import/extensions": [2, "ignorePackages", {
             "ts": "never",
-            "tsx": "never",
-            "json": "never"
+            "tsx": "never"
             }],
-        "react/jsx-filename-extension": [2, { "extensions": [".tsx", ".json"] }],
+        "react/jsx-filename-extension": [2, { "extensions": [".tsx"] }],
         "@typescript-eslint/explicit-module-boundary-types": 0
     }
 }


### PR DESCRIPTION
# Summary
rule "import/extensions" needed additional option "ignorePackages"

This is the StackOverflow question that helped me find the answer: https://stackoverflow.com/questions/59265981/typescript-eslint-missing-file-extension-ts-import-extensions